### PR TITLE
Change dependency direction

### DIFF
--- a/.github/workflows/move.yml
+++ b/.github/workflows/move.yml
@@ -19,12 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aptos-labs/actions/install-aptos-cli@main
-      - name: Setup
-        run: ./contracts/setup.sh
       - uses: aptos-labs/actions/test-move@main
         with:
-          SKIP_INSTALLING_CLI: 'true'
+          # SKIP_INSTALLING_CLI: 'true'
           SKIP_FMT: 'true'
           SKIP_LINT: 'true'
           WORKING_DIRECTORY: contracts

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -2,3 +2,4 @@
 build/
 tmp/
 gas-profiling/
+deps/

--- a/contracts/Move.toml
+++ b/contracts/Move.toml
@@ -9,13 +9,12 @@ moneyfi = "0x97c9ffc7143c5585090f9ade67d19ac95f3b3e7008ed86c73c947637e2862f56"
 stablecoin = "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b"
 usdc = "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b"
 usdt = "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b"
-hyperion = "0x8b4a2c4bb53857c718a04c020b98f8c2e1f99a68b0f57389a8bf5434cd22e05c"
 
 [dev-addresses]
 
 [dependencies]
 Aries = { local = "deps/aries" }
-dex = { local = "deps/hyperion-interface" }
+dex = { local = "deps/hyperion-interface", addr_subst = { hyperion = "dex_contract" } }
 ThalaStakedLPT = { local = "deps/thala-interface/stake" }
 ThalaSwapV2 = { local = "deps/thala-interface/swap" }
 ThalaLSD = { local = "deps/thala-interface/thala_lsd" }

--- a/contracts/deps/tapp-interface/router/Move.toml
+++ b/contracts/deps/tapp-interface/router/Move.toml
@@ -9,6 +9,6 @@ tapp = "0x487e905f899ccb6d46fdaec56ba1e0c4cf119862a16c409904b8c78fab1f5e8a"
 [dev-addresses]
 tapp = "0xaaaaa"
 
-# [dependencies]
-# AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }
+[dependencies]
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-token-objects" }
 

--- a/contracts/deps/tapp-interface/router/sources/hook_factory.move
+++ b/contracts/deps/tapp-interface/router/sources/hook_factory.move
@@ -2,29 +2,29 @@ module tapp::hook_factory {
 
     struct IncentiveReward has copy, drop {
         token: address,
-        amount: u64,
+        amount: u64
     }
-    
+
     struct PoolIncentiveMeta has copy, drop, store, key {
         pool_addr: address,
         assets: vector<address>,
-        reserves: vector<u64>,
+        reserves: vector<u64>
     }
-    
+
     struct PoolMeta has copy, drop, store, key {
         pool_addr: address,
         hook_type: u8,
         assets: vector<address>,
         reserves: vector<u64>,
         is_paused: bool,
-        platform_fee_rate: u64,
+        platform_fee_rate: u64
     }
 
-    public fun pool_meta(arg0: address) : PoolMeta acquires PoolMeta {
+    public fun pool_meta(arg0: address): PoolMeta acquires PoolMeta {
         *borrow_global<PoolMeta>(arg0)
     }
 
-    public fun pool_meta_assets(arg0: &PoolMeta) : vector<address> {
+    public fun pool_meta_assets(arg0: &PoolMeta): vector<address> {
         arg0.assets
     }
 }

--- a/contracts/deps/tapp-interface/router/sources/integration.move
+++ b/contracts/deps/tapp-interface/router/sources/integration.move
@@ -1,7 +1,5 @@
 module tapp::integration {
-    use std::signer;
-    use std::vector;
-    public fun add_liquidity(arg0: &signer, arg1: vector<u8>) : (u64, address) {
+    public fun add_liquidity(arg0: &signer, arg1: vector<u8>): (u64, address) {
         (0, @0xa)
     }
 }

--- a/contracts/deps/tapp-interface/router/sources/position.move
+++ b/contracts/deps/tapp-interface/router/sources/position.move
@@ -2,22 +2,22 @@ module tapp::position {
     struct PositionMeta has copy, drop, store, key {
         hook_type: u8,
         pool_addr: address,
-        position_idx: u64,
+        position_idx: u64
     }
-    
-    public fun hook_type(arg0: &PositionMeta) : u8 {
+
+    public fun hook_type(arg0: &PositionMeta): u8 {
         arg0.hook_type
     }
 
-    public fun pool_id(arg0: &PositionMeta) : address {
+    public fun pool_id(arg0: &PositionMeta): address {
         arg0.pool_addr
     }
-    
-    public fun position_idx(arg0: &PositionMeta) : u64 {
+
+    public fun position_idx(arg0: &PositionMeta): u64 {
         arg0.position_idx
     }
-    
-    public fun position_meta(arg0: address) : PositionMeta acquires PositionMeta {
+
+    public fun position_meta(arg0: address): PositionMeta acquires PositionMeta {
         *borrow_global<PositionMeta>(arg0)
     }
 }

--- a/contracts/deps/tapp-interface/router/sources/router.move
+++ b/contracts/deps/tapp-interface/router/sources/router.move
@@ -1,13 +1,11 @@
 module tapp::router {
-    use std::signer;
-    use std::vector;
     use aptos_framework::object;
     use tapp::hook_factory;
     struct PoolCap has key {
-        extend_ref: object::ExtendRef,
+        extend_ref: object::ExtendRef
     }
 
-     public entry fun swap(arg0: &signer, arg1: vector<u8>) {
+    public entry fun swap(arg0: &signer, arg1: vector<u8>) {
         abort 0x1;
     }
 
@@ -19,7 +17,7 @@ module tapp::router {
         abort 0x1;
     }
 
-    public fun get_pool_meta(arg0: address) : hook_factory::PoolMeta {
+    public fun get_pool_meta(arg0: address): hook_factory::PoolMeta {
         hook_factory::pool_meta(arg0)
     }
 }

--- a/contracts/deps/tapp-interface/stable/sources/stable.move
+++ b/contracts/deps/tapp-interface/stable/sources/stable.move
@@ -1,5 +1,4 @@
 module stable::stable {
-    use std::vector;
     struct Position has copy, drop, store {
         index: u64,
         shares: u256
@@ -18,8 +17,8 @@ module stable::stable {
 
     public fun calculate_pending_rewards(// pool address, position index
         arg0: address, arg1: u64
-    ): vector<CampaignReward> {   
-        vector::empty<CampaignReward>()
+    ): vector<CampaignReward> {
+        vector[]
     }
 
     public fun campaign_reward_amount(arg0: &CampaignReward): u64 {

--- a/contracts/deps/tapp-interface/views/Move.toml
+++ b/contracts/deps/tapp-interface/views/Move.toml
@@ -6,6 +6,6 @@ authors = []
 [addresses]
 views = "0xf5840b576a3a6a42464814bc32ae1160c50456fb885c62be389b817e75b2a385"
 
-# [dependencies]
+[dependencies]
 # AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", rev = "mainnet", subdir = "aptos-framework" }
 

--- a/contracts/deps/tapp-interface/views/sources/stable_views.move
+++ b/contracts/deps/tapp-interface/views/sources/stable_views.move
@@ -1,7 +1,6 @@
 module views::stable_views {
-    use std::vector;
     public fun calc_ratio_amounts(arg0: address, arg1: u256): vector<u256> {
-        vector::empty<u256>()
+        vector[]
     }
 
     public fun position_shares(arg0: address, arg1: u64): u256 {

--- a/contracts/deps/thala-interface/stake/Move.toml
+++ b/contracts/deps/thala-interface/stake/Move.toml
@@ -10,13 +10,13 @@ thala_staked_lpt_deployer = "0x1bf23f0881f8fa149500ff6b7a047f608967c028a8ad7a210
 # [dependencies.RateLimiter]
 # local = "../rate_limiter"
 
-[dependencies.MasterchefLib]
-local = "../masterschef"
+# [dependencies.MasterchefLib]
+# local = "../masterschef"
 
-# [dependencies.AptosFramework]
-# git = "https://github.com/aptos-labs/aptos-framework.git"
-# rev = "mainnet"
-# subdir = "aptos-framework"
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
 
 # [dependencies.FixedPoint64]
 # git = "https://github.com/ThalaLabs/fixed_point64.git"

--- a/contracts/deps/thala-interface/stake/sources/stake.move
+++ b/contracts/deps/thala-interface/stake/sources/stake.move
@@ -4,7 +4,7 @@ module thala_staked_lpt::staked_lpt {
     use aptos_framework::object;
     use aptos_framework::fungible_asset;
     use aptos_framework::function_info;
-    use masterchef_lib::masterchef;
+    // use masterchef_lib::masterchef;
     use aptos_std::string_utils;
 
     struct NewRewardEvent has drop, store {
@@ -29,7 +29,7 @@ module thala_staked_lpt::staked_lpt {
     struct Farming has key {
         deposit_updating_farming: function_info::FunctionInfo,
         withdraw_updating_farming: function_info::FunctionInfo,
-        farming: masterchef::FarmingCore,
+        // farming: masterchef::FarmingCore,
         boost_scaling_factor_bps: u64,
         max_boost_multiplier_bps: u64,
         reward_store_extend_ref: object::ExtendRef,

--- a/contracts/deps/thala-interface/swap/Move.toml
+++ b/contracts/deps/thala-interface/swap/Move.toml
@@ -11,10 +11,10 @@ thalaswap_v2_deployer = "0x1bf23f0881f8fa149500ff6b7a047f608967c028a8ad7a2100caa
 # git = "https://github.com/ThalaLabs/fixed_point64.git"
 # rev = "mainnet"
 
-# [dependencies.AptosFramework]
-# git = "https://github.com/aptos-labs/aptos-framework.git"
-# rev = "mainnet"
-# subdir = "aptos-framework"
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
 
 # [dependencies.RateLimiter]
 # local = "../rate_limiter"

--- a/contracts/deps/thala-interface/swap/sources/coin_wrapper.move
+++ b/contracts/deps/thala-interface/swap/sources/coin_wrapper.move
@@ -1,6 +1,4 @@
 module thalaswap_v2::coin_wrapper {
-    use std::signer;
-    use std::vector;
     use aptos_framework::object;
     use aptos_framework::fungible_asset;
 
@@ -20,14 +18,13 @@ module thalaswap_v2::coin_wrapper {
     }
 
     public entry fun swap_exact_in_stable<T0>(// T0 AptosCoin
-        arg0: &signer, 
-        arg1: object::Object<pool::Pool>, 
-        arg2: object::Object<fungible_asset::Metadata>, 
-        arg3: u64, 
-        arg4: object::Object<fungible_asset::Metadata>, 
+        arg0: &signer,
+        arg1: object::Object<pool::Pool>,
+        arg2: object::Object<fungible_asset::Metadata>,
+        arg3: u64,
+        arg4: object::Object<fungible_asset::Metadata>,
         arg5: u64
     ) {
         abort(0)
     }
-
 }

--- a/contracts/sources/storage.move
+++ b/contracts/sources/storage.move
@@ -3,10 +3,6 @@ module moneyfi::storage {
 
     use moneyfi::access_control;
 
-    friend moneyfi::wallet_account;
-    friend moneyfi::vault;
-    friend moneyfi::strategy_aries;
-
     const PHANTOM_OBJECT_SEED: vector<u8> = b"storage::PHANTOM_OBJECT";
 
     struct Storage has key {
@@ -53,17 +49,9 @@ module moneyfi::storage {
         object::create_object_address(&get_address(), seed)
     }
 
-    // -- Private
-
-    fun get_signer(): signer acquires Storage {
-        let storage = borrow_global<Storage>(@moneyfi);
-
-        object::generate_signer_for_extending(&storage.extend_ref)
-    }
-
     /// Creates a child object using the provided seed.
     /// Note: If the child object is intended to hold a fungible asset, use `create_child_object_with_phantom_owner` instead.
-    public(friend) fun create_child_object(seed: vector<u8>): ExtendRef acquires Storage {
+    public fun create_child_object(seed: vector<u8>): ExtendRef acquires Storage {
         let (extend_ref, _) = create_child_object_impl(seed);
 
         extend_ref
@@ -71,9 +59,7 @@ module moneyfi::storage {
 
     /// Creates a child object with a phantom owner, meaning the object does not have a real owner.
     /// This ensures that only the child object itself can transfer tokens from its fungible asset store.
-    public(friend) fun create_child_object_with_phantom_owner(
-        seed: vector<u8>
-    ): ExtendRef acquires Storage {
+    public fun create_child_object_with_phantom_owner(seed: vector<u8>): ExtendRef acquires Storage {
         let (extend_ref, transfer_ref) = create_child_object_impl(seed);
 
         // transfer ownership to phantom object
@@ -81,6 +67,14 @@ module moneyfi::storage {
         transfer_ownership(&transfer_ref, phantom_object_addr);
 
         extend_ref
+    }
+
+    // -- Private
+
+    fun get_signer(): signer acquires Storage {
+        let storage = borrow_global<Storage>(@moneyfi);
+
+        object::generate_signer_for_extending(&storage.extend_ref)
     }
 
     fun create_child_object_impl(seed: vector<u8>): (ExtendRef, TransferRef) acquires Storage {

--- a/contracts/sources/strategy.move
+++ b/contracts/sources/strategy.move
@@ -1,3 +1,4 @@
+/// This module is deprecated. Please do not add new strategies here.
 module moneyfi::strategy {
     use std::vector;
     use std::error;
@@ -6,7 +7,6 @@ module moneyfi::strategy {
 
     use moneyfi::wallet_account::WalletAccount;
     use moneyfi::strategy_hyperion;
-    use moneyfi::strategy_aries;
     use moneyfi::strategy_thala;
     use moneyfi::strategy_tapp;
 
@@ -32,9 +32,6 @@ module moneyfi::strategy {
         if (strategy == STRATEGY_HYPERION) {
             let (v1, v2, v3) = strategy_hyperion::get_strategy_stats(asset);
             vector::append(&mut stats, vector[v1, v2, v3]);
-        } else if (strategy == STRATEGY_ARIES) {
-            let (v1, v2, v3) = strategy_aries::get_stats(&asset);
-            vector::append(&mut stats, vector[v1, v2, v3]);
         } else if (strategy == STRATEGY_THALA) {
             let (v1, v2, v3) = strategy_thala::get_strategy_stats(asset);
             vector::append(&mut stats, vector[v1, v2, v3]);
@@ -58,10 +55,6 @@ module moneyfi::strategy {
             return strategy_hyperion::deposit_fund_to_hyperion_single(
                 account, asset, amount, extra_data
             );
-        };
-
-        if (strategy == STRATEGY_ARIES) {
-            return strategy_aries::deposit_to_vault(account, asset, amount, extra_data);
         };
 
         if (strategy == STRATEGY_THALA) {
@@ -94,12 +87,6 @@ module moneyfi::strategy {
     ): (u64, u64, u64) {
         if (strategy == STRATEGY_HYPERION) {
             return strategy_hyperion::withdraw_fund_from_hyperion_single(
-                account, asset, min_amount, extra_data
-            );
-        };
-
-        if (strategy == STRATEGY_ARIES) {
-            return strategy_aries::withdraw_from_vault(
                 account, asset, min_amount, extra_data
             );
         };

--- a/contracts/sources/vault.move
+++ b/contracts/sources/vault.move
@@ -132,7 +132,7 @@ module moneyfi::vault {
     struct DepositToStrategyEvent has drop, store {
         wallet_id: vector<u8>,
         asset: Object<Metadata>,
-        /// Deprecated,  keep for upgrade compatibility, always set to 0
+        /// Deprecated, retained for upgrade compatibility, always set to 0
         strategy: u8,
         amount: u64,
         timestamp: u64
@@ -142,6 +142,7 @@ module moneyfi::vault {
     struct WithdrawFromStrategyEvent has drop, store {
         wallet_id: vector<u8>,
         asset: Object<Metadata>,
+        /// Deprecated, retained for upgrade compatibility, always set to 0
         strategy: u8,
         amount: u64,
         interest_amount: u64,

--- a/contracts/sources/vault.move
+++ b/contracts/sources/vault.move
@@ -4,6 +4,7 @@ module moneyfi::vault {
     use std::vector;
     use std::string;
     use std::option;
+    use aptos_std::type_info::{Self, TypeInfo};
     use aptos_framework::ordered_map::{Self, OrderedMap};
     use aptos_framework::object::{Self, Object, ObjectCore, ExtendRef};
     use aptos_framework::event;
@@ -27,6 +28,7 @@ module moneyfi::vault {
     const E_DEPOSIT_NOT_ALLOWED: u64 = 2;
     const E_WITHDRAW_NOT_ALLOWED: u64 = 3;
     const E_ASSET_NOT_SUPPORTED: u64 = 4;
+    const E_DEPRECATED: u64 = 5;
 
     // -- Structs
     struct Config has key {
@@ -60,6 +62,12 @@ module moneyfi::vault {
     struct Vault has key {
         extend_ref: ExtendRef,
         assets: OrderedMap<address, VaultAsset>
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    struct StrategyRegistry has key {
+        // type => deposit address
+        strategies: OrderedMap<TypeInfo, address>
     }
 
     struct VaultAsset has store {
@@ -124,6 +132,7 @@ module moneyfi::vault {
     struct DepositToStrategyEvent has drop, store {
         wallet_id: vector<u8>,
         asset: Object<Metadata>,
+        /// Deprecated,  keep for upgrade compatibility, always set to 0
         strategy: u8,
         amount: u64,
         timestamp: u64
@@ -440,6 +449,7 @@ module moneyfi::vault {
         );
     }
 
+    /// Deprecated by deposit_to_strategy_vault
     public entry fun deposit_to_strategy(
         sender: &signer,
         wallet_id: vector<u8>,
@@ -477,6 +487,7 @@ module moneyfi::vault {
         );
     }
 
+    /// Deprecated by withdrawn_from_strategy
     public entry fun withdraw_from_strategy(
         sender: &signer,
         wallet_id: vector<u8>,
@@ -662,14 +673,17 @@ module moneyfi::vault {
     }
 
     public entry fun update_tick(
-        sender: &signer,
-        wallet_id: vector<u8>,
-        strategy_id: u8,
-        extra_data: vector<vector<u8>>
+        _sender: &signer,
+        _wallet_id: vector<u8>,
+        _strategy_id: u8,
+        _extra_data: vector<vector<u8>>
     ) {
-        access_control::must_be_service_account(sender);
-        let account = wallet_account::get_wallet_account(wallet_id);
-        strategy::update_tick(strategy_id, &account, extra_data);
+        // Deprecated, function retained for upgrade compatibility
+        abort(E_DEPRECATED);
+
+        // access_control::must_be_service_account(sender);
+        // let account = wallet_account::get_wallet_account(wallet_id);
+        // strategy::update_tick(strategy_id, &account, extra_data);
     }
 
     public entry fun swap_assets(
@@ -743,6 +757,28 @@ module moneyfi::vault {
         );
     }
 
+    public entry fun register_strategy<T>(
+        sender: &signer, deposit_addr: address
+    ) acquires Vault, StrategyRegistry {
+        access_control::must_be_admin(sender);
+
+        let vault_addr = get_vault_address();
+        let vault = borrow_global<Vault>(vault_addr);
+
+        if (!exists<StrategyRegistry>(vault_addr)) {
+            move_to(
+                &vault.get_vault_signer(),
+                StrategyRegistry { strategies: ordered_map::new() }
+            );
+        };
+
+        let registry = borrow_global_mut<StrategyRegistry>(vault_addr);
+        let vault_type = type_info::type_of<T>();
+        assert!(!registry.strategies.contains(&vault_type));
+
+        registry.strategies.add(vault_type, deposit_addr);
+    }
+
     // -- Views
     #[view]
     public fun get_assets(): (vector<address>, vector<u128>) acquires Vault {
@@ -796,12 +832,147 @@ module moneyfi::vault {
         ordered_map::keys(&config.supported_assets)
     }
 
+    #[view]
+    public fun get_strategy_registry(): OrderedMap<TypeInfo, address> acquires StrategyRegistry {
+        let vault_addr = get_vault_address();
+        let registry = borrow_global<StrategyRegistry>(vault_addr);
+
+        registry.strategies
+    }
+
     // -- Public
 
     public fun get_lp_token(): Object<Metadata> acquires LPToken {
         let lptoken = borrow_global<LPToken>(@moneyfi);
 
         lptoken.token
+    }
+
+    public fun deposit_to_strategy_vault<T>(
+        sender: &signer,
+        wallet_id: vector<u8>,
+        asset: Object<Metadata>,
+        amount: u64
+    ) acquires Vault, StrategyRegistry {
+        let account = &wallet_account::get_wallet_account(wallet_id);
+        let account_signer = &wallet_account::get_wallet_account_signer(account);
+        let strategy_addr = get_strategy_address<T>();
+        assert!(signer::address_of(sender) == strategy_addr);
+
+        primary_fungible_store::transfer(account_signer, asset, strategy_addr, amount);
+        wallet_account::distributed_fund(account, &asset, amount);
+
+        let vault_addr = get_vault_address();
+        let vault = borrow_global_mut<Vault>(vault_addr);
+        let asset_data = vault.get_vault_asset_mut(&asset);
+
+        asset_data.total_distributed_amount =
+            asset_data.total_distributed_amount + (amount as u128);
+
+        event::emit(
+            DepositToStrategyEvent {
+                wallet_id,
+                asset,
+                strategy: 0,
+                amount,
+                timestamp: now_seconds()
+            }
+        );
+    }
+
+    public fun withdrawn_from_strategy<T>(
+        sender: &signer,
+        wallet_id: vector<u8>,
+        asset: Object<Metadata>,
+        deposited_amount: u64,
+        withdrawn_amount: u64,
+        withdraw_fee: u64,
+        gas_fee: u64
+    ) acquires Config, Vault, StrategyRegistry {
+        let strategy_addr = get_strategy_address<T>();
+        assert!(signer::address_of(sender) == strategy_addr);
+
+        let account = wallet_account::get_wallet_account(wallet_id);
+        let config = borrow_global<Config>(@moneyfi);
+
+        let vault_addr = get_vault_address();
+        let vault = borrow_global_mut<Vault>(vault_addr);
+        let asset_data = vault.get_vault_asset_mut(&asset);
+
+        assert!(withdraw_fee <= withdrawn_amount);
+        assert!(asset_data.total_distributed_amount >= (deposited_amount as u128));
+
+        let collected_amount = withdrawn_amount - withdraw_fee;
+        let interest_amount = 0;
+        let loss_amount = 0;
+        if (deposited_amount > collected_amount) {
+            loss_amount = deposited_amount - collected_amount;
+        } else {
+            interest_amount = collected_amount - deposited_amount;
+        };
+        interest_amount =
+            if (interest_amount > gas_fee) {
+                interest_amount - gas_fee
+            } else { 0 };
+
+        asset_data.total_distributed_amount =
+            asset_data.total_distributed_amount - (deposited_amount as u128);
+        asset_data.total_amount = asset_data.total_amount + (interest_amount as u128);
+        asset_data.total_amount =
+            if (asset_data.total_amount > (loss_amount as u128)) {
+                asset_data.total_amount - (loss_amount as u128)
+            } else { 0 };
+
+        let system_fee = config.calc_system_fee(&account, interest_amount);
+        let total_fee = withdraw_fee + system_fee + gas_fee;
+        if (total_fee > 0) {
+            let account_signer = wallet_account::get_wallet_account_signer(&account);
+            primary_fungible_store::transfer(
+                &account_signer, asset, vault_addr, total_fee
+            );
+        };
+
+        collected_amount = collected_amount - system_fee;
+        if (system_fee > 0) {
+            collected_amount = collected_amount - gas_fee;
+
+            let (remaining_fee, referral_fees) =
+                config.calc_referral_shares(&account, system_fee);
+            asset_data.total_fee_amount = asset_data.total_fee_amount + remaining_fee;
+            asset_data.pending_fee_amount = asset_data.pending_fee_amount
+                + remaining_fee;
+            asset_data.add_referral_fees(&referral_fees);
+        };
+
+        wallet_account::collected_fund(
+            &account,
+            &asset,
+            deposited_amount,
+            collected_amount,
+            interest_amount,
+            system_fee
+        );
+
+        event::emit(
+            WithdrawFromStrategyEvent {
+                wallet_id,
+                asset,
+                strategy: 0,
+                amount: collected_amount,
+                interest_amount,
+                system_fee,
+                timestamp: now_seconds()
+            }
+        );
+    }
+
+    public fun get_strategy_address<T>(): address acquires StrategyRegistry {
+        let vault_addr = get_vault_address();
+        let registry = borrow_global<StrategyRegistry>(vault_addr);
+        let vault_type = type_info::type_of<T>();
+        assert!(registry.strategies.contains(&vault_type));
+
+        *registry.strategies.borrow(&vault_type)
     }
 
     // -- Private

--- a/contracts/sources/wallet_account.move
+++ b/contracts/sources/wallet_account.move
@@ -5,6 +5,7 @@ module moneyfi::wallet_account {
     use std::error;
     use std::option::{Self, Option};
     use aptos_std::math64;
+    use aptos_std::type_info;
     use aptos_std::ordered_map::{Self, OrderedMap};
     use aptos_framework::event;
     use aptos_framework::object::{Self, Object, ExtendRef};
@@ -15,11 +16,6 @@ module moneyfi::wallet_account {
     use moneyfi::storage;
 
     friend moneyfi::vault;
-    friend moneyfi::strategy;
-    friend moneyfi::strategy_hyperion;
-    friend moneyfi::strategy_thala;
-    friend moneyfi::strategy_tapp;
-    friend moneyfi::strategy_aries;
 
     #[test_only]
     friend moneyfi::wallet_account_test;
@@ -311,9 +307,12 @@ module moneyfi::wallet_account {
             asset_data.interest_share_amount + interest_share_amount;
     }
 
-    public(friend) fun set_strategy_data<T: store + drop + copy>(
+    public fun set_strategy_data<T: store + drop + copy>(
         account: &Object<WalletAccount>, data: T
     ) acquires StrategyData, WalletAccount {
+        let data_type = type_info::type_of<T>();
+        assert!(data_type.account_address() == @moneyfi);
+
         let addr = object::object_address(account);
         if (!exists<StrategyData<T>>(addr)) {
             let account_signer = get_wallet_account_signer(account);
@@ -324,7 +323,7 @@ module moneyfi::wallet_account {
         }
     }
 
-    public(friend) fun get_strategy_data<T: store + copy>(
+    public fun get_strategy_data<T: store + copy>(
         account: &Object<WalletAccount>
     ): T acquires StrategyData {
         let addr = object::object_address(account);
@@ -441,7 +440,7 @@ module moneyfi::wallet_account {
         object::generate_signer_for_extending(&wallet_account.extend_ref)
     }
 
-    public(friend) fun get_referrer_addresses(
+    public fun get_referrer_addresses(
         account: &Object<WalletAccount>, max: u8
     ): vector<address> acquires WalletAccount {
         let referrers = vector[];

--- a/contracts/sources/wallet_account.move
+++ b/contracts/sources/wallet_account.move
@@ -16,6 +16,10 @@ module moneyfi::wallet_account {
     use moneyfi::storage;
 
     friend moneyfi::vault;
+    // TODO: remove these friend dependencies after refactor strategies
+    friend moneyfi::strategy_hyperion;
+    friend moneyfi::strategy_thala;
+    friend moneyfi::strategy_tapp;
 
     #[test_only]
     friend moneyfi::wallet_account_test;


### PR DESCRIPTION
## Goals

Refactor the codebase to prevent any single module from depending on all strategy modules.  
This change helps avoid the "DEPENDENCY_LIMIT_REACHED" error.

## Implementation

- [x] Remove friend dependencies in `storage` module: change `friend fun` to  `public fun`
- [x] Remove friend dependencies in wallet_account: strategies cannot call `wallet_account` to get `WalletAccount` signer
- [x] `vault` module: 
   - Move entry functions: `deposit_to_vault`, `withdraw_from_vault`, `swap` to strategies
   - Deprecate `update_ticks` method
- Strategies: must register with `vault`. Refactor current  strategies:
   - [x]  Aries
   - [ ] Hyperion
   - [ ] Thala
   - [ ] Tapp
- [ ] Deprecate `strategy` module

## Breaking changes for client

- Entry functions moved from `vault` to strategies 
-  Event `DepositToStrategyEvent` and `WithdrawFromStrategyEvent` no longer include the strategy ID
